### PR TITLE
Fix screen bump when hover on toggle

### DIFF
--- a/src/lib/components/ToggleTheme.svelte
+++ b/src/lib/components/ToggleTheme.svelte
@@ -18,7 +18,7 @@
 	 * Custom class naming and tailwindcss styling
 	 */
 	export let className: string = ''
-	let finalClass = `${className} text-black dark:text-white hover:border-y-2 dark:hover:border-yellow-300 hover:border-blue-900`
+	let finalClass = `${className} text-black dark:text-white hover:border-y-2 dark:hover:border-yellow-300 hover:-mt-2 hover:border-blue-900`
 </script>
 
 <button


### PR DESCRIPTION
This is a _hotfix_ that fixes the whole page moving slightly downwards when hovering over the dark/light-theme toggle button in the navbar.

Next-step:
- Fix the placement of the toggle itself on hover.

